### PR TITLE
Adding ids to Projects filtering

### DIFF
--- a/docs/examples/full_schema.txt
+++ b/docs/examples/full_schema.txt
@@ -46,7 +46,7 @@
     permits_by_neighborhood(nbrhd_ids: [String], after: String, before: String): [Permit]
     permit_tasks(permit_numbers: [String], date_field: String, before: String, after: String, permit_groups: [String]): [PermitTask]
     inspections(permit_numbers: [String], date_field: String, before: String, after: String, permit_groups: [String]): [Inspection]
-    cip_projects(names: [String], categories: [String], zipcodes: [String]): [CIPProject]
+    cip_projects(names: [String], categories: [String], zipcodes: [String], ids: [String]): [CIPProject]
     cip_project_categories: [CIPProjectCategory]
     projects (status: [String], priority: [String], reqtype: String, after: String, before: String): [ITProject]
     pcard_transactions (before: String, after: String): [PCardTransaction]

--- a/src/api/cip/cip_resolvers.js
+++ b/src/api/cip/cip_resolvers.js
@@ -87,7 +87,7 @@ const resolvers = {
       on A.munis_project_number = B.project_id
       WHERE 1 = 1
       `;
-      
+
       const names = args.names;
       const ids = args.ids;
       const categories = args.categories;
@@ -125,7 +125,6 @@ const resolvers = {
       }
     
       query += ' ORDER BY A.display_name';
-      console.log("this is the query", query);
 
       return pool.query(query)
       .then(result => {

--- a/src/api/cip/cip_resolvers.js
+++ b/src/api/cip/cip_resolvers.js
@@ -88,12 +88,20 @@ const resolvers = {
       `;
       // let query = 'SELECT * FROM amd.coa_cip_project_information ';
       const names = args.names;
+      console.log(args)
+      const ids = args.ids
       if (names && names.length > 0) {
         if (names.length <= 0) return [];
         const namesList = names.map(p => {
           return `'${p}'`;
         }).join(',');
         query += `WHERE project in (${namesList})`;
+      } else if (ids && ids.length > 0) {
+        if (ids.length <= 0) return [];
+        const idList = ids.map(p => {
+          return `'${p}'`;
+        }).join(',');
+        query += `WHERE gis_id in (${idList})`;
       } else {
         const categories = args.categories;
         const zipcodes = args.zipcodes;

--- a/src/api/cip/cip_resolvers.js
+++ b/src/api/cip/cip_resolvers.js
@@ -84,22 +84,21 @@ const resolvers = {
       left join internal.capital_projects_master_categories as C
       on A.category = C.category_name
       left join simplicity.cip_ltd_view as B
-      on A.munis_project_number = B.project_id 
+      on A.munis_project_number = B.project_id
+      WHERE 1 = 1
       `;
-      // let query = 'SELECT * FROM amd.coa_cip_project_information ';
+      
       const names = args.names;
       const ids = args.ids;
       const categories = args.categories;
       const zipcodes = args.zipcodes;
-      let haveWhere = false;
 
       if (names && names.length > 0) {
         if (names.length <= 0) return [];
         const namesList = names.map(p => {
           return `'${p}'`;
         }).join(',');
-        query += `WHERE project in (${namesList})`;
-        haveWhere = true;
+        query += ` AND project in (${namesList})`;
       } 
       
       if (ids && ids.length > 0) {
@@ -107,44 +106,26 @@ const resolvers = {
         const idList = ids.map(p => {
           return `'${p}'`;
         }).join(',');
-        // query += `WHERE gis_id in (${idList})`;
-        if (haveWhere) {
-          query += 'AND ';
-        } else {
-          query += 'WHERE ';
-        }
-        query += `gis_id in (${idList})`;
-        haveWhere = true;
+        query += ` AND gis_id in (${idList})`;
       }
 
       if (categories && categories.length > 0) {
         const cList = categories.map(p => {
           return `'${p}'`;
         }).join(',');
-        // query += `WHERE category in (${cList})`;
-        if (haveWhere) {
-          query += 'AND ';
-        } else {
-          query += 'WHERE ';
-        }
-        query += `category in (${cList})`;
-        haveWhere = true;
+        query += ` AND category in (${cList})`;
       }
 
       if (zipcodes && zipcodes.length > 0) {
         const zList = zipcodes.map(p => {
           return `'${p}'`;
         }).join(',');
-        if (haveWhere) {
-          query += 'AND ';
-        } else {
-          query += 'WHERE ';
-        }
-        query += `zip_code in (${zList})`;
+
+        query += ` AND zip_code in (${zList})`;
       }
     
       query += ' ORDER BY A.display_name';
-      // console.log("this is the query", query);
+      console.log("this is the query", query);
 
       return pool.query(query)
       .then(result => {

--- a/src/api/cip/cip_resolvers.js
+++ b/src/api/cip/cip_resolvers.js
@@ -117,32 +117,32 @@ const resolvers = {
         haveWhere = true;
       }
 
-        if (categories && categories.length > 0) {
-          const cList = categories.map(p => {
-            return `'${p}'`;
-          }).join(',');
-          // query += `WHERE category in (${cList})`;
-          if (haveWhere) {
-            query += 'AND ';
-          } else {
-            query += 'WHERE ';
-          }
-          query += `category in (${cList})`;
-          haveWhere = true;
+      if (categories && categories.length > 0) {
+        const cList = categories.map(p => {
+          return `'${p}'`;
+        }).join(',');
+        // query += `WHERE category in (${cList})`;
+        if (haveWhere) {
+          query += 'AND ';
+        } else {
+          query += 'WHERE ';
         }
+        query += `category in (${cList})`;
+        haveWhere = true;
+      }
 
-        if (zipcodes && zipcodes.length > 0) {
-          const zList = zipcodes.map(p => {
-            return `'${p}'`;
-          }).join(',');
-          if (haveWhere) {
-            query += 'AND ';
-          } else {
-            query += 'WHERE ';
-          }
-          query += `zip_code in (${zList})`;
+      if (zipcodes && zipcodes.length > 0) {
+        const zList = zipcodes.map(p => {
+          return `'${p}'`;
+        }).join(',');
+        if (haveWhere) {
+          query += 'AND ';
+        } else {
+          query += 'WHERE ';
         }
-      
+        query += `zip_code in (${zList})`;
+      }
+    
       query += ' ORDER BY A.display_name';
       // console.log("this is the query", query);
 

--- a/src/api/cip/cip_resolvers.js
+++ b/src/api/cip/cip_resolvers.js
@@ -88,31 +88,49 @@ const resolvers = {
       `;
       // let query = 'SELECT * FROM amd.coa_cip_project_information ';
       const names = args.names;
-      console.log(args)
-      const ids = args.ids
+      const ids = args.ids;
+      const categories = args.categories;
+      const zipcodes = args.zipcodes;
+      let haveWhere = false;
+
       if (names && names.length > 0) {
         if (names.length <= 0) return [];
         const namesList = names.map(p => {
           return `'${p}'`;
         }).join(',');
         query += `WHERE project in (${namesList})`;
-      } else if (ids && ids.length > 0) {
+        haveWhere = true;
+      } 
+      
+      if (ids && ids.length > 0) {
         if (ids.length <= 0) return [];
         const idList = ids.map(p => {
           return `'${p}'`;
         }).join(',');
-        query += `WHERE gis_id in (${idList})`;
-      } else {
-        const categories = args.categories;
-        const zipcodes = args.zipcodes;
-        let haveWhere = false;
+        // query += `WHERE gis_id in (${idList})`;
+        if (haveWhere) {
+          query += 'AND ';
+        } else {
+          query += 'WHERE ';
+        }
+        query += `gis_id in (${idList})`;
+        haveWhere = true;
+      }
+
         if (categories && categories.length > 0) {
           const cList = categories.map(p => {
             return `'${p}'`;
           }).join(',');
-          query += `WHERE category in (${cList})`;
+          // query += `WHERE category in (${cList})`;
+          if (haveWhere) {
+            query += 'AND ';
+          } else {
+            query += 'WHERE ';
+          }
+          query += `category in (${cList})`;
           haveWhere = true;
         }
+
         if (zipcodes && zipcodes.length > 0) {
           const zList = zipcodes.map(p => {
             return `'${p}'`;
@@ -124,9 +142,9 @@ const resolvers = {
           }
           query += `zip_code in (${zList})`;
         }
-      }
+      
       query += ' ORDER BY A.display_name';
-      // console.log(query);
+      // console.log("this is the query", query);
 
       return pool.query(query)
       .then(result => {

--- a/src/api/simplicity_schema.js
+++ b/src/api/simplicity_schema.js
@@ -42,7 +42,7 @@ const baseSchema = `
     permits_by_neighborhood(nbrhd_ids: [String], after: String, before: String): [Permit]
     permit_tasks(permit_numbers: [String], date_field: String, before: String, after: String, permit_groups: [String]): [PermitTask]
     inspections(permit_numbers: [String], date_field: String, before: String, after: String, permit_groups: [String]): [Inspection]
-    cip_projects(names: [String], categories: [String], zipcodes: [String]): [CIPProject]
+    cip_projects(names: [String], categories: [String], zipcodes: [String], ids: [String]): [CIPProject]
     cip_project_categories: [CIPProjectCategory]
     projects (status: [String], priority: [String], reqtype: String, after: String, before: String): [ITProject]
     pcard_transactions (before: String, after: String): [PCardTransaction]


### PR DESCRIPTION
Context for Rick: Al and I were chatting this morning and looking at the code, and realized there's already a "names" filter for the projects endpoint. It seemed more sensible to add a new id filter, rather than adding creating a whole new project endpoint.

Added the ability to filter /projects by ids, and made it so you can filter by all variables at the same time. Before, you could only filter by name || (zipcodes && categories) for some reason, I believe.

(I won't merge this request until next week)

